### PR TITLE
Bug fixes to report section in sonata_simulator

### DIFF
--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -491,8 +491,9 @@ Examples::
            "cells": "Column",
            "sections": "soma",
            "type": "summation",
-           "variable_name": "i_membrane, IClamp",
+           "variable_name": "i_membrane",
            "unit": "nA",
+           "dt":0.1,
            "start_time": 0,
            "end_time": 500,
            "enabled": true


### PR DESCRIPTION
Fixes two bugs in the current report in the sonata_simulator.rst doc:
1. Adds missing dt
2. Removes IClamp from report. With the addition of MembraneCurrentSource.mod to neurodamus-models, the IClamp variable is used exclusively to represent physical electrodes, si it should not be included in a report on the membrane current.