### PR TITLE
Stimulus electrodes

### DIFF
--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -452,6 +452,28 @@ Note: fields marked Mandatory* depend on which ornstein_uhlenbeck version is sel
    represents_physical_electrode  boolean    Optional     Default is False. If True, the signal will be implemented using a NEURON SEClamp mechanism, if a conductance source, or a NEURON IClamp mechanism, if a current source. The SEClamp and IClamp produce an electrode current which is not included in the calculation of extracellular signals, so this option should be used to represent a physical electrode. If the noise signal represents synaptic input, `represents_physical_electrode` should be set to False, in which case the signal will be implemented using a ConductanceSource mechanism or a MembraneCurrentSource mechanism, which are identical to SEClamp and IClamp, respectively, but produce a membrane current, which is included in the calculation of the extracellular signal.
    ============================== ========== ============ ==========================================
 
+uniform_e_field (extracellular_stimulation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generates an temporally-oscillating extracellular potential field whose gradient (i.e., E field) is constant.
+The oscillation is defined as the sum of two sinusoids.
+
+.. table::
+
+   ============================== ========== ============ ==========================================
+   Property                       Type       Requirement  Description
+   ============================== ========== ============ ==========================================
+   Ex_0                           float      Mandatory    Peak amplitude of the first sinusoid in the x-direction, in V/m
+   Ey_0                           float      Mandatory    Peak amplitude of the first sinusoid in the y-direction, in V/m
+   Ez_0                           float      Mandatory    Peak amplitude of the first sinusoid in the z-direction, in V/m
+   frequency_0                    float      Mandatory    Frequency of the first sinusoid, in Hz
+   Ex_1                           float      Optional     Peak amplitude of the second sinusoid in the x-direction, in V/m. If not provided, assumed to be 0
+   Ey_1                           float      Optional     Peak amplitude of the second sinusoid in the y-direction, in V/m. If not provided, assumed to be 0
+   Ez_1                           float      Optional     Peak amplitude of the second sinusoid in the z-direction, in V/m. If not provided, assumed to be 0
+   frequency_1                    float      Optional     Frequency of the second sinusoid, in Hz. If not provided, assumed to be 0
+   ramp_up_time                   float      Optional     Duration during which the signal ramps up linearly from 0, in ms. If not provided, assume no ramp-up time
+   ramp_down_time                 float      Optional     Duration during which the signal ramps down linearly from 0, in ms. If not provided, assume no ramp-down time
+   ============================== ========== ============ ==========================================
+
 reports
 -------
 

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -224,7 +224,7 @@ Dictionary of dictionaries with each member describing one pattern of stimulus t
    ============================== ========== ============ ==========================================
    Property                       Type       Requirement  Description
    ============================== ========== ============ ==========================================
-   module                         text       Mandatory    The type of stimulus dictating additional parameters (see addtional tables below). Supported values: "linear", "relative_linear", "pulse", "sinusoidal", "subthreshold", "hyperpolarizing", "synapse_replay", "seclamp", "noise", "shot_noise", "relative_shot_noise", "absolute_shot_noise", "ornstein_uhlenbeck", "relative_ornstein_uhlenbeck".
+   module                         text       Mandatory    The type of stimulus dictating additional parameters (see addtional tables below). Supported values: "linear", "relative_linear", "pulse", "sinusoidal", "subthreshold", "hyperpolarizing", "synapse_replay", "seclamp", "noise", "shot_noise", "relative_shot_noise", "absolute_shot_noise", "ornstein_uhlenbeck", "relative_ornstein_uhlenbeck", "uniform_e_field".
    input_type                     text       Mandatory    The type of the input with the reserved values : "spikes", "extracellular_stimulation", "current_clamp", "voltage_clamp", "conductance". Should correspond according to the module (see additional tables below). Currently, not validated by BBP simulation which will use the appropriate input_type regardless of the string passed.
    delay                          float      Mandatory    Time in ms when input is activated.
    duration                       float      Mandatory    Time duration in ms for how long input is activated.

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -465,10 +465,12 @@ The oscillation is defined as the sum of two sinusoids.
    Ex_0                           float      Mandatory    Peak amplitude of the first sinusoid in the x-direction, in V/m
    Ey_0                           float      Mandatory    Peak amplitude of the first sinusoid in the y-direction, in V/m
    Ez_0                           float      Mandatory    Peak amplitude of the first sinusoid in the z-direction, in V/m
-   frequency_0                    float      Mandatory    Frequency of the first sinusoid, in Hz
-   Ex_1                           float      Optional     Peak amplitude of the second sinusoid in the x-direction, in V/m. If not provided, assumed to be 0
-   Ey_1                           float      Optional     Peak amplitude of the second sinusoid in the y-direction, in V/m. If not provided, assumed to be 0
-   Ez_1                           float      Optional     Peak amplitude of the second sinusoid in the z-direction, in V/m. If not provided, assumed to be 0
+   frequency_0                    float      Optional     Frequency of the first sinusoid, in Hz. If not provided, assumed to be 0
+   Ex_1                           float      Optional*    Peak amplitude of the second sinusoid in the x-direction, in V/m. If not provided, assumed to be 0. If one of Ex_1, Ey_1, or Ez_1 is provided, then all must be provided.
+   Ey_1                           float      Optional*    Peak amplitude of the second sinusoid in the y-direction, in V/m. If not provided, assumed to be 0. If one of Ex_1, Ey_1, or Ez_1 is
+ provided, then all must be provided.
+   Ez_1                           float      Optional*    Peak amplitude of the second sinusoid in the z-direction, in V/m. If not provided, assumed to be 0. If one of Ex_1, Ey_1, or Ez_1 is
+ provided, then all must be provided.
    frequency_1                    float      Optional     Frequency of the second sinusoid, in Hz. If not provided, assumed to be 0
    ramp_up_time                   float      Optional     Duration during which the signal ramps up linearly from 0, in ms. If not provided, assume no ramp-up time
    ramp_down_time                 float      Optional     Duration during which the signal ramps down linearly from 0, in ms. If not provided, assume no ramp-down time

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -472,8 +472,8 @@ The oscillation is defined as the sum of two sinusoids.
    Ez_1                           float      Optional*    Peak amplitude of the second sinusoid in the z-direction, in V/m. If not provided, assumed to be 0. If one of Ex_1, Ey_1, or Ez_1 is
  provided, then all must be provided.
    frequency_1                    float      Optional     Frequency of the second sinusoid, in Hz. If not provided, assumed to be 0
-   ramp_up_time                   float      Optional     Duration during which the signal ramps up linearly from 0, in ms. If not provided, assume no ramp-up time
-   ramp_down_time                 float      Optional     Duration during which the signal ramps down linearly from 0, in ms. If not provided, assume no ramp-down time
+   ramp_up_time                   float      Optional     Duration during which the signal ramps up linearly from 0, in ms. If not provided, assume no ramp-up time (note that the specified "duration" parameter is not inclusive of this ramp-up time)
+   ramp_down_time                 float      Optional     Duration during which the signal ramps down linearly from 0, in ms. If not provided, assume no ramp-down time (note that the specified "duration" parameter is not inclusive of the ramp-down time)
    ============================== ========== ============ ==========================================
 
 reports


### PR DESCRIPTION
As requested in [Issue #374 in neurodamus](https://github.com/openbraininstitute/neurodamus/issues/374), I've added a spec for an extracellular stimulus block in sonata_simulation.rst. 

The spec defines a stimulus corresponding to the minimum functionality for our use case: either a spatially-uniform E-field varying sinusoidally in time, or the sum of two such E fields.