### PR TITLE
Add clarifications for conditions mechanisms and modifications

### DIFF
--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -200,8 +200,8 @@ Parameters required for modifications
    The referenced compartment set must be valid, sorted, and free of duplicates (as in reports).
    The json file specified by ``compartment_sets_file`` is described here in :ref:`File: compartment_sets.json <compartment_sets_definition>` under :ref:`report`.
 
-   For ``configure_all_sections`` if the mechanism or variable specified in ``section_configure``does not exist for a section will results in simulation failure.
-   e.g. for the modification ``no_SK_E2`` below, if SK_E2 is not available in the myelin section, the simulation will fail.
+   For ``configure_all_sections``, the ``section_configure`` is applied only to sections that have all the referenced attributes. 
+   Sections missing any referenced attribute are skipped. A warning is logged if the configuration applies to zero sections.
 
 example::
 

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -158,7 +158,7 @@ Parameters defining global experimental conditions.
    spike_location                  text       Optional    The spike detection location. Can be either ‘soma’ or 'AIS' for detecting spikes in either the soma or axon initial segment, respectively. Default is 'soma'.
    extracellular_calcium           float      Optional    Extracellular calcium concentration. When this parameter is provided, apply it to the synapse uHill parameter to scale the U parameter of synapses (py-neurodamus only feature). If not specified, U is set directly as read from edges file.
    randomize_gaba_rise_time        boolean    Optional    When true, enable legacy behavior to randomize the GABA_A rise time in the helper functions. Default is false which will use a prescribed value for GABA_A rise time.
-   mechanisms                                 Optional    Properties to assign values to variables in synapse MOD files.
+   mechanisms                                 Optional    Properties to assign values to GLOBAL variables in synapse or mechanism MOD files.
                                                           The format is a dictionary with keys being the SUFFIX names of MOD files (unique names of mechanisms) and values being dictionaries of variable names in the MOD files and their values. Read about `NMODL2 SUFFIX description here <https://nrn.readthedocs.io/en/8.2.0/hoc/modelspec/programmatic/mechanisms/nmodl2.html#suffix>`_.
    modifications                              Optional    List of dictionaries with each member describing a modification that mimics experimental manipulations to the circuit. They are executed in the order as being read from the file.
    =============================== ========== =========== ====================================
@@ -198,7 +198,10 @@ Parameters required for modifications
 .. note::
    If ``compartment_set`` is defined, ``node_set`` must not be specified.
    The referenced compartment set must be valid, sorted, and free of duplicates (as in reports).
-   The json file specified by ``compartment_sets_file`` is described here in :ref:`File: compartment_sets.json <compartment_sets_definition>` under :ref:`report`..
+   The json file specified by ``compartment_sets_file`` is described here in :ref:`File: compartment_sets.json <compartment_sets_definition>` under :ref:`report`.
+
+   For ``configure_all_sections`` if the mechanism or variable specified in ``section_configure``does not exist for a section will results in simulation failure.
+   e.g. for the modification ``no_SK_E2`` below, if SK_E2 is not available in the myelin section, the simulation will fail.
 
 example::
 

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -219,7 +219,10 @@ example::
            },
            "GluSynapse": {
                "property_z": "string"
-           }
+           },
+           "StochKv3": {
+                "vmin": 0.0
+            }
        },
        "modifications": [
            {

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -187,11 +187,12 @@ Parameters required for modifications
                                                           
                                                           For ``section_list``, ``section`` and ``compartment_set`` manipulations, a snippet of python code to perform one or more assignments involving attributes as follows:
                                                           
-                                                          ``section_list``: entries should be of the form, e.g. ``"apical.gbar_NaTg = 0.0; apical.cm = 1"``. This will set the gbar_NaTg to 0 and cm to 1 for all sections in the apical dendrites.
+                                                          ``section_list``: entries should be of the form, e.g. ``"apical.gbar_NaTg = 0.0; apical.cm = 1"``. This will set the gbar_NaTg to 0 and cm to 1 for all sections in the apical dendrites. All statements must use the same section list name, such as ``apical`` in the above example.
                                                           
-                                                          ``section``: entries should be of the form, e.g. ``"apic[10].gbar_KTst = 0; apic[10].gbar_NaTg = 0"``. This will set the gbar_KTst to 0 and gbar_NaTg to 0 for all segments of apic[10] section.
+                                                          ``section``: entries should be of the form, e.g. ``"apic[10].gbar_KTst = 0; apic[10].gbar_NaTg = 0"``. This will set the gbar_KTst to 0 and gbar_NaTg to 0 for all segments of apic[10] section. All statements must reference the same specific section, such as ``apic[10]`` in the above example.
                                                           
                                                           ``compartment_set``: entries should be of the form, e.g. ``"gbar_KTst = 0; gbar_NaTg = 0"``. This will set the gbar_KTst to 0 and gbar_NaTg to 0 for all segments contained in the property ``compartment_set``. Note, when the property ``type`` is set ``compartment_set``, you should also specify the property ``compartment_set``. In addition, the simulation must declare the ``compartment_sets_file`` at the top level. See :ref:`compartment_sets_file`.
+                                                          Sections and segments referenced in the ``compartment_sets_file`` need not be the same section or section list.
    compartment_set                 text       Optional    The ``compartment_set`` to use for manipulation from ``compartment_sets_file`` json file. The ``type`` must be ``compartment_set``. In the example below, "dend_ca_hotspot_name" is the compartment_set name.
    =============================== ========== =========== ====================================
 

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -196,7 +196,7 @@ Parameters required for modifications
    =============================== ========== =========== ====================================
 
 .. note::
-   For all modification types (``section_list``, ``section``, ``compartment_set``), the ``section_configure`` is applied only to sections/segments that possess all the referenced attributes. Sections or segments missing any referenced attribute are skipped with a log message. A warning is logged if the configuration applies to zero sections or segments.
+   For all modification types (``section_list``, ``section``, ``compartment_set``), the ``section_configure`` is applied only to sections/segments that possess all the referenced attributes. A warning is logged if the configuration applies to zero sections or segments.
    If ``compartment_set`` is defined, ``node_set`` must not be specified.
    The referenced compartment set must be valid, sorted, and free of duplicates (as in reports).
    The json file specified by ``compartment_sets_file`` is described here in :ref:`File: compartment_sets.json <compartment_sets_definition>` under :ref:`report`.

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -196,12 +196,10 @@ Parameters required for modifications
    =============================== ========== =========== ====================================
 
 .. note::
+   For all modification types (``section_list``, ``section``, ``compartment_set``), the ``section_configure`` is applied only to sections/segments that possess all the referenced attributes. Sections or segments missing any referenced attribute are skipped with a log message. A warning is logged if the configuration applies to zero sections or segments.
    If ``compartment_set`` is defined, ``node_set`` must not be specified.
    The referenced compartment set must be valid, sorted, and free of duplicates (as in reports).
    The json file specified by ``compartment_sets_file`` is described here in :ref:`File: compartment_sets.json <compartment_sets_definition>` under :ref:`report`.
-
-   For ``configure_all_sections``, the ``section_configure`` is applied only to sections that have all the referenced attributes. 
-   Sections missing any referenced attribute are skipped. A warning is logged if the configuration applies to zero sections.
 
 example::
 

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -198,6 +198,9 @@ Parameters required for modifications
 
 .. note::
    For all modification types (``section_list``, ``section``, ``compartment_set``), the ``section_configure`` is applied only to sections/segments that possess all the referenced attributes. A warning is logged if the configuration applies to zero sections or segments.
+   To reference variables in multiple section types or section indices, multiple ``modifications`` dictionaries must be added to the file. User should not combine in a single ``modifications`` dictionary.
+   e.g. ``"type": "section_list"``, one dictionary for ``apical`` sections with ``"section_configure": "apical.gbar_NaTg = 0.0"`` and another dictionary for ``basal`` sections with ``"section_configure": "basal.gbar_NaTg = 0.0"``.
+   Multiple modifications of the same type can be defined in ``section_configure`` e.g. ``"section_configure": "apical.gbar_NaTg = 0.0; apical.cm = 1"``.
    If ``compartment_set`` is defined, ``node_set`` must not be specified.
    The referenced compartment set must be valid, sorted, and free of duplicates (as in reports).
    The json file specified by ``compartment_sets_file`` is described here in :ref:`File: compartment_sets.json <compartment_sets_definition>` under :ref:`report`.


### PR DESCRIPTION
- For condition: mechanisms -- Clarify that Properties can be assigned to values to GLOBAL variables in other **mechanisms** in addition to synapses. Added an example to show GLOBAL `vmin` variable assignment in the `StochKv3` ion channel.

- Clarify condition: modifications -- section_configure is applied only to sections or segments that have all the referenced attributes. Sections or segments missing any referenced attribute are silently skipped. A warning is logged if the configuration applies to zero sections or segments.