### PR TITLE
The SONATA specification puts the `target_simulator` in the circuit_config.

### DIFF
--- a/source/sonata_config.rst
+++ b/source/sonata_config.rst
@@ -84,6 +84,19 @@ They can be found also under :ref:`populations <population_config_dict>` where i
 .. [#f1] Mandatory (at least one) for :ref:`biophysical node populations<biophysical_node_type>`
 .. [#f2] Mandatory for :ref:`biophysical node populations<biophysical_node_type>`
 
+
+.. _target_simulator:
+
+target_simulator
+----------------
+
+*Optional*.
+
+A parameter specifying which simulator is expected to be able to simulate the circuit.
+Supported values : `NEURON` and `CORENEURON`, `LearningEngine`, and `Brian2`.
+Default is `NEURON`.
+
+
 alternate_morphologies
 ^^^^^^^^^^^^^^^^^^^^^^
 An *optional* dictionary for different representations of the morphologies than the default .swc.

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -48,7 +48,9 @@ target_simulator
 
 *Optional*.
 
-A parameter specifying which simulator to run. Supported values : "NEURON" and "CORENEURON". Default is "NEURON".
+A parameter specifying which simulator to run.
+See :ref:`Circuit Config target_simulator <target_simulator>` for valid values.
+If not specified, the value from the `network`'s `circuit_config.json` is used.
 
 node_sets_file
 --------------


### PR DESCRIPTION
* add it there; since the biophysics may also require it
* clarify the behavior when it's specified in the simulation_config