### PR TITLE
Make model_template optional for virtual populations

### DIFF
--- a/source/sonata_tech.rst
+++ b/source/sonata_tech.rst
@@ -224,7 +224,7 @@ This is for `virtual` nodes (i.e., source nodes of `projections`).
     Group              Field                           Type       Requirement   Description
     ================== =============================== ========== ============= ==================================================================================================
     /0                 ``model_type``                  utf8       Mandatory     `virtual`
-    /0                 ``model_template``              utf8       Mandatory     See details below.
+    /0                 ``model_template``              utf8       Optional      See details below. Deprecated for virtual populations; should be omitted.
     /                  ``node_type_id``                int        Mandatory     Set to -1. Foreign key to node type csv file not used at BBP..
     ================== =============================== ========== ============= ==================================================================================================
 
@@ -260,7 +260,8 @@ model_template
 
 The ``model_template`` is used to reference a template or class describing the electrophysical properties and mechanisms of the node(s).
 Its value and interpretation is context-dependent on the corresponding ‘model_type’.
-When there is no applicable model template for a given model type (i.e. model_type=virtual) it is assigned a value of NULL.
+When there is no applicable model template for a given model type (i.e. model_type=virtual) the field should be omitted.
+For backward compatibility, existing files that contain ``model_template`` with empty strings for virtual populations are still valid but the field will be ignored.
 Otherwise, within BBP, it uses a colon-separated string-pair with the following syntax: ``hoc:resource`` where ``resource`` is a reference to the template file-name or class.
 
 Edge File

--- a/source/sonata_tech.rst
+++ b/source/sonata_tech.rst
@@ -224,7 +224,7 @@ This is for `virtual` nodes (i.e., source nodes of `projections`).
     Group              Field                           Type       Requirement   Description
     ================== =============================== ========== ============= ==================================================================================================
     /0                 ``model_type``                  utf8       Mandatory     `virtual`
-    /0                 ``model_template``              utf8       Optional      See details below. Deprecated for virtual populations; should be omitted.
+    /0                 ``model_template``              utf8       Optional      See details below.
     /                  ``node_type_id``                int        Mandatory     Set to -1. Foreign key to node type csv file not used at BBP..
     ================== =============================== ========== ============= ==================================================================================================
 

--- a/source/sonata_tech.rst
+++ b/source/sonata_tech.rst
@@ -261,7 +261,6 @@ model_template
 The ``model_template`` is used to reference a template or class describing the electrophysical properties and mechanisms of the node(s).
 Its value and interpretation is context-dependent on the corresponding ‘model_type’.
 When there is no applicable model template for a given model type (i.e. model_type=virtual) the field should be omitted.
-For backward compatibility, existing files that contain ``model_template`` with empty strings for virtual populations are still valid but the field will be ignored.
 Otherwise, within BBP, it uses a colon-separated string-pair with the following syntax: ``hoc:resource`` where ``resource`` is a reference to the template file-name or class.
 
 Edge File


### PR DESCRIPTION
Virtual populations have a model_template column filled with empty strings. This column has no meaning for virtual nodes and clutters the table view of neuron properties.

- Changed `model_template` from `Mandatory` to `Optional` in the virtual population table.
- Added description: "Deprecated for virtual populations; should be omitted."
- Updated the `model_template` description text to state the field should be omitted for virtual populations rather than assigned NULL.
- Added a backward-compatibility note: existing files with empty strings remain valid.

Old circuits that include `model_template` with empty strings for virtual populations are still spec-compliant. No existing data is invalidated by this change.

## Issues

Originally required in: [# Make `model_template` optional for virtual populations](https://github.com/openbraininstitute/prod-build-circuit/issues/34)

Fix: https://github.com/openbraininstitute/sonata-extension/issues/36