### PR TITLE
Fix electrodes spec: scaling_factors units mV/nA → V/nA

### DIFF
--- a/source/sonata_tech.rst
+++ b/source/sonata_tech.rst
@@ -680,7 +680,7 @@ The format of the weights file is described below:
                                                                                                                      LineSource means the analytic solution for line sources of current, in infinite homogeneous extracellular media.
                                                                                                                      PointSource refers to the analytic solution for point source approximation, for the same assumptions.
   /electrodes/{electrodename}/{population_name} electrode_id            uint       1                   Mandatory     Index of the column corresponding to this electrode in /electrodes/{population_name}/scaling_factors
-  /electrodes/{population_name}                 scaling_factors         float64    Total_comp x N_elec Mandatory     Scaling factor for each compartment in the corresponding neuron, in mV/nA
+  /electrodes/{population_name}                 scaling_factors         float64    Total_comp x N_elec Mandatory     Scaling factor for each compartment in the corresponding neuron, in V/nA
   /{population_name}                            node_ids                uint       N_nodes             Mandatory     List of node ids. Node ids not listed here are to be ignored
   /{population_name}                            offsets                 uint       N_nodes + 1         Mandatory     The offset for each node in the scaling_factors field
   ============================================= ======================= ========== =================== ============= ==========================================


### PR DESCRIPTION
Correct the documented units for scaling_factors from mV/nA to V/nA.

- Aligns with BlueRecording implementation (openbraininstitute/BlueRecording#102)
- suggested by @joseph-tharayil here: https://github.com/openbraininstitute/BlueRecording/issues/93#issuecomment-4958694898